### PR TITLE
replace librosa.load with pysoundfile.read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,11 @@ before_install:
 
 install:
     # install your own package into the environment
-    # pip install -e rather than setup.py, so that coverage can find the source
-    - pip install -e ./
+    - pip install -e .[tests]
 
 script:
     - python --version
-    - nosetests --with-coverage --cover-erase --cover-package=pyrubberband -v -w tests/
+    - py.test
 
 after_success:
     - coveralls

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -11,7 +11,7 @@ conda_create ()
     conda update -q conda
     conda config --add channels pypi
     conda info -a
-    deps='pip numpy scipy pandas requests nose coverage numpydoc matplotlib sphinx scikit-learn seaborn'
+    deps='pip numpy scipy pandas requests pytest pytest-cov coverage numpydoc matplotlib sphinx scikit-learn seaborn'
 
     conda create -q -n $ENV_NAME "python=$1" $deps
 }
@@ -19,7 +19,7 @@ conda_create ()
 if [ ! -f "$HOME/env/miniconda.sh" ]; then
     mkdir -p $HOME/env
     pushd $HOME/env
-    
+
         # Download miniconda packages
         wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
 
@@ -42,9 +42,9 @@ if [ ! -f "$HOME/env/miniconda.sh" ]; then
 
             source activate $ENV_NAME
 
-            pip install librosa
+            pip install pysoundfile
             pip install python-coveralls
-            
+
             source deactivate
 
             export PATH=$OLDPATH

--- a/README.md
+++ b/README.md
@@ -12,14 +12,22 @@ For now, this just provides lightweight wrappers for pitch-shifting and time-str
 All processing is done via the command-line through files on disk.  In the future, this could be improved
 by directly wrapping the C library instead.
 
+Install Rubberband on OS X
+--------------------------
+
+```
+brew install https://gist.githubusercontent.com/faroit/b67c1708cdc1f9c4ddc9/raw/942bbedded22f05abab0d09b52383e7be4aee237/rubberband.rb
+```
+
 Example usage
 -------------
 
 ```python
 
->>> import librosa
+>>> import soundfile as sf
 >>> import pyrubberband as pyrb
->>> y, sr = librosa.load(librosa.util.example_audio_file())
+>>> # Read mono wav file
+>>> y, sr = sf.read("test.wav")
 >>> # Play back at double speed
 >>> y_stretch = pyrb.time_stretch(y, sr, 2.0)
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,20 +17,20 @@ Example usage
 -------------
 .. code-block:: python
 
-    >>> import librosa
+    >>> import soundfile as sf
     >>> import pyrubberband as pyrb
-    >>> y, sr = librosa.load(librosa.util.example_audio_file())
+    >>> y, sr = sf.read("myfile.wav")
     >>> # Play back at double speed
     >>> y_stretch = pyrb.time_stretch(y, sr, 2.0)
     >>> # Play back two semi-tones higher
     >>> y_shift = pyrb.pitch_shift(y, sr, 2)
-    
+
 
 API Reference
 -------------
 .. toctree::
     :maxdepth: 3
-    
+
     api
 
 Contribute

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore docs/conf.py --cov-report term-missing --cov pyrubberband --pep8

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,20 @@ setup(
     keywords='audio music sound',
     license='ISC',
     install_requires=[
-        'librosa>=0.4',
         'six',
+        'pysoundfile>=0.8.0',
     ],
     extras_require={
-        'docs': ['numpydoc']
-    }
+        'docs': ['numpydoc'],
+        'tests': [
+            'pytest',
+            'pytest-cov',
+            'pytest-pep8'
+        ]
+    },
+    test_require=[
+        'pytest',
+        'pytest-cov',
+        'pytest-pep8'
+    ]
 )

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -3,57 +3,105 @@
 
 import pyrubberband
 import numpy as np
-
-from nose.tools import raises
-
-def test_stretch():
-
-    sr = 8000
-    duration = 5
-    y = np.zeros(sr * duration)
-
-    def __test(rate):
-        y_s = pyrubberband.time_stretch(y, sr, rate=rate)
-
-        assert np.allclose(rate * len(y_s), len(y))
-
-    for rate in [0.5, 1.0, 2.0]:
-        yield __test, rate
-
-    for bad_rate in [-1, -0.5, 0]:
-        yield raises(ValueError)(__test), bad_rate
+import pytest
 
 
-def synth(sr, duration, freq):
+def synth(sr, num_samples, freq):
+    return np.sin(
+        2 * np.pi * (freq / sr) * np.linspace(
+            0, 1, num=num_samples
+        )
+    )
 
-    return np.sin(2 * np.pi * (freq / sr) * np.linspace(0, 1, num=duration * sr))
 
-def test_pitch():
+@pytest.fixture(params=([1, 2]))
+def length(request):
+    return request.param
 
-    sr = 8000
-    duration = 5
-    freq = 500.0
-    y = synth(sr, duration, freq)
 
-    def __test(n_steps):
+@pytest.fixture(params=([16000, 44100, 48000]))
+def sr(request):
+    return request.param
 
-        y_s = pyrubberband.pitch_shift(y, sr, n_steps)
 
-        # Make sure we have the same duration
-        assert np.allclose(len(y), len(y_s))
+@pytest.fixture
+def num_samples(length, sr, request):
+    return int(length * sr)
 
-        # compare to directly synthesize target track
 
-        # we'll compare normalized power spectra to avoid phase issues
-        t_freq = freq * 2.0**(n_steps / 12.0)
-        y_f = synth(sr, duration, t_freq)
+@pytest.fixture(params=([500.0, 440.0, 123.0]))
+def freq(request):
+    return request.param
 
-        s_s = np.abs(np.fft.rfft(y_s))
-        s_f = np.abs(np.fft.rfft(y_f))
 
-        assert np.allclose(s_s / s_s[0], s_f / s_f[0], atol=1e-2)
+@pytest.fixture(params=([-1.5, -1, -0.5, 0, 0.5, 1, 1.5]))
+def n_step(request):
+    return request.param
 
-        
-    for n_steps in [-1.5, -1, -0.5, 0, 0.5, 1, 1.5]:
 
-        yield __test, n_steps
+@pytest.fixture(params=([None, 1, 2, 6]))
+def channels(request):
+    return request.param
+
+
+@pytest.fixture
+def random_signal(channels, num_samples):
+    if channels is not None:
+        shape = (num_samples, channels)
+    else:
+        shape = (num_samples,)
+    return np.random.random(shape)
+
+
+@pytest.mark.parametrize(
+    "rate",
+    [
+        0.5,
+        1.0,
+        2.0,
+        pytest.mark.xfail(-1, raises=ValueError),
+        pytest.mark.xfail(-0.5, raises=ValueError),
+        pytest.mark.xfail(0, raises=ValueError)
+    ]
+)
+def test_stretch(sr, random_signal, num_samples, rate):
+    '''Test shape of random signals with stretching
+    factor of various rate.
+    '''
+
+    # input signal of shape (channels, sr * duration)
+    y = random_signal
+
+    y_s = pyrubberband.time_stretch(y, sr, rate=rate)
+
+    # test if output dimension matches input dimension
+    assert y_s.ndim == y.ndim
+
+    # check shape
+    if y.ndim > 1:
+        # check number of channels
+        assert y.shape[1] == y_s.shape[1]
+    else:
+        # check num_samples (stretching factor)
+        assert np.allclose(y_s.shape[0] * rate, y.shape[0])
+
+
+def test_pitch(sr, num_samples, freq, n_step):
+
+    y = synth(sr, num_samples, freq)
+
+    y_s = pyrubberband.pitch_shift(y, sr, n_step)
+
+    # Make sure we have the same duration
+    assert np.allclose(len(y), len(y_s))
+
+    # compare to directly synthesize target track
+
+    # we'll compare normalized power spectra to avoid phase issues
+    t_freq = freq * 2.0**(n_step / 12.0)
+    y_f = synth(sr, num_samples, t_freq)
+
+    s_s = np.abs(np.fft.rfft(y_s))
+    s_f = np.abs(np.fft.rfft(y_f))
+
+    assert np.allclose(s_s / s_s[0], s_f / s_f[0], atol=1e-2)


### PR DESCRIPTION
I really like librosa but importing it only for the read/write capability [can make things complicated](https://github.com/bmcfee/librosa/issues/281).  There are other libraries which only focus on audio I/O like [pysoundfile](https://github.com/bastibe/PySoundFile) and therefore have less dependencies and are more flexible. 

This PR therefore removes librosa dependency and replace it with pysoundfile. I know that pysoundfile is not optimal because it not pure python but since timestretching/pitch shifting is often applied on general audio files a library which supports a large number of input and output formats like portaudio is beneficial. Also to my knowledge there are currently no better solutions for python.

I've also added a note howto easily install rubberband cli on mac by providing a homebrew recipe 
