### PR TITLE
long window mode for signals with sr <= 210Hz

### DIFF
--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -178,7 +178,7 @@ def pitch_shift(y, sr, n_steps, rbargs=None):
 
     rbargs.setdefault('--pitch', n_steps)
 
-     # long window hack for low-sr signals
+    # long window hack for low-sr signals
     if sr <= 210:
         rbargs.setdefault('-q', '--window-long')
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -138,6 +138,10 @@ def time_stretch(y, sr, rate, rbargs=None):
 
     rbargs.setdefault('--tempo', rate)
 
+    # long window hack for low-sr signals
+    if sr <= 210:
+        rbargs.setdefault('-q', '--window-long')
+
     return __rubberband(y, sr, **rbargs)
 
 
@@ -173,5 +177,9 @@ def pitch_shift(y, sr, n_steps, rbargs=None):
         rbargs = dict()
 
     rbargs.setdefault('--pitch', n_steps)
+
+     # long window hack for low-sr signals
+    if sr <= 210:
+        rbargs.setdefault('-q', '--window-long')
 
     return __rubberband(y, sr, **rbargs)

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -19,7 +19,7 @@ def length(request):
     return request.param
 
 
-@pytest.fixture(params=([16000, 44100, 48000]))
+@pytest.fixture(params=([125, 16000, 44100, 48000]))
 def sr(request):
     return request.param
 


### PR DESCRIPTION
Pyrubberband will hang when faced with low-sr signals unless the `--window-long` flag is set. This PR adds that flag for signals below 210Hz and allows the process to complete.