### PR TITLE
Added timemap stretch option

### DIFF
--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -181,7 +181,7 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
     if rbargs is None:
         rbargs = dict()
 
-    time_stretch = time_map[-1][1] * 1.0 /time_map[-1][0]
+    time_stretch = time_map[-1][1] * 1.0 / time_map[-1][0]
 
     rbargs.setdefault('--time', time_stretch)
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -18,7 +18,7 @@ import numpy as np
 import soundfile as sf
 
 
-__all__ = ['time_stretch', 'pitch_shift']
+__all__ = ['time_stretch', 'pitch_shift', 'timemap_stretch']
 
 __RUBBERBAND_UTIL = 'rubberband'
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -180,6 +180,7 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
     ------
     ValueError
         if `time_map` is not monotonic
+        if `time_map[-1][0]` is not the input audio length
     '''
 
     if rbargs is None:

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -156,9 +156,11 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
         Sampling rate of `y`
 
     time_map : list
-        Each element is a tuple `t` of length 2 which correspond to the input frame and desired output frame.
+        Each element is a tuple `t` of length 2 which correspond to the input
+         frame and desired output frame.
         If t[1] < t[0] the track will be sped up in this area.
-        time_map[-1] must correspond to the lengths of the input audio and output audio.
+        time_map[-1] must correspond to the lengths of the input audio and
+         output audio.
 
     rbargs
         Additional keyword parameters for rubberband
@@ -178,25 +180,24 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
 
     if rbargs is None:
         rbargs = dict()
-        
+
     time_stretch = time_map[-1][1]/time_map[-1][0]
 
     rbargs.setdefault('--time', time_stretch)
 
-    
     fs, stretch_file_name = tempfile.mkstemp(suffix='.txt')
     os.close(fs)
 
     stretch_file = open(stretch_file_name, 'w')
     for t in time_map:
-        stretch_file.write("%d %d\n" %(t[0], t[1]))
-    stretch_file.close()    
-    
+        stretch_file.write("%d %d\n" % (t[0], t[1]))
+    stretch_file.close()
+
     rbargs.setdefault('--timemap', stretch_file_name)
-    
+
     y_stretch = __rubberband(y, sr, **rbargs)
     os.unlink(stretch_file_name)
-    
+
     return y_stretch
 
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -206,13 +206,19 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
 
     stretch_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt',
                                                delete=False)
-    for t in time_map:
-        stretch_file.write('{:0} {:1}\n'.format(t[0], t[1]))
-    stretch_file.close()
+    try:
+        for t in time_map:
+            stretch_file.write('{:0} {:1}\n'.format(t[0], t[1]))
+        stretch_file.close()
 
-    rbargs.setdefault('--timemap', stretch_file.name)
-    y_stretch = __rubberband(y, sr, **rbargs)
-    os.unlink(stretch_file.name)
+        rbargs.setdefault('--timemap', stretch_file.name)
+        y_stretch = __rubberband(y, sr, **rbargs)
+    except:
+        print(sys.exc_info()[0])
+        raise
+    finally:
+        # Remove temp file
+        os.unlink(stretch_file.name)
 
     return y_stretch
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -189,11 +189,9 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
 
     is_positive = all(time_map[i][0] >= 0 and time_map[i][1] >= 0
                       for i in range(len(time_map)))
-    
     is_monotonic = all(time_map[i][0] <= time_map[i+1][0] and
                        time_map[i][1] <= time_map[i+1][1]
                        for i in range(len(time_map)-1))
-    
     if not is_positive:
         raise ValueError('time_map should be non-negative')
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -213,9 +213,6 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
 
         rbargs.setdefault('--timemap', stretch_file.name)
         y_stretch = __rubberband(y, sr, **rbargs)
-    except:
-        print(sys.exc_info()[0])
-        raise
     finally:
         # Remove temp file
         os.unlink(stretch_file.name)

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -180,15 +180,23 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
     ------
     ValueError
         if `time_map` is not monotonic
+        if `time_map` is not non-negative
         if `time_map[-1][0]` is not the input audio length
     '''
 
     if rbargs is None:
         rbargs = dict()
 
+    is_positive = all(time_map[i][0] >= 0 and time_map[i][1] >= 0
+                      for i in range(len(time_map)))
+    
     is_monotonic = all(time_map[i][0] <= time_map[i+1][0] and
                        time_map[i][1] <= time_map[i+1][1]
                        for i in range(len(time_map)-1))
+    
+    if not is_positive:
+        raise ValueError('time_map should be non-negative')
+
     if not is_monotonic:
         raise ValueError('time_map is not monotonic')
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -158,13 +158,13 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
         Sampling rate of `y`
 
     time_map : list
-        Each element is a tuple `t` of length 2 which corresponds to the 
+        Each element is a tuple `t` of length 2 which corresponds to the
         source sample position and target sample position.
 
         If `t[1] < t[0]` the track will be sped up in this area.
 
         `time_map[-1]` must correspond to the lengths of the source audio and
-        target audio.   
+        target audio.
 
     rbargs
         Additional keyword parameters for rubberband
@@ -185,8 +185,8 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
     if rbargs is None:
         rbargs = dict()
 
-    is_monotonic = all(time_map[i][0] <= time_map[i+1][0] and 
-                       time_map[i][1] <= time_map[i+1][1] 
+    is_monotonic = all(time_map[i][0] <= time_map[i+1][0] and
+                       time_map[i][1] <= time_map[i+1][1]
                        for i in range(len(time_map)-1))
     if not is_monotonic:
         raise ValueError('time_map is not monotonic')
@@ -200,7 +200,7 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
     stretch_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt',
                                                delete=False)
     for t in time_map:
-        stretch_file.write('{:0} {:1}\n'.format(t[0], t[1])) 
+        stretch_file.write('{:0} {:1}\n'.format(t[0], t[1]))
     stretch_file.close()
 
     rbargs.setdefault('--timemap', stretch_file.name)

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -181,7 +181,7 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
     if rbargs is None:
         rbargs = dict()
 
-    time_stretch = time_map[-1][1]/time_map[-1][0]
+    time_stretch = time_map[-1][1] * 1.0 /time_map[-1][0]
 
     rbargs.setdefault('--time', time_stretch)
 

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -141,6 +141,65 @@ def time_stretch(y, sr, rate, rbargs=None):
     return __rubberband(y, sr, **rbargs)
 
 
+def timemap_stretch(y, sr, time_map, rbargs=None):
+    '''Apply a timemap stretch to an audio time series.
+
+    This uses the `time` and `timemap` form for rubberband.
+
+
+    Parameters
+    ----------
+    y : np.ndarray [shape=(n,) or (n, c)]
+        Audio time series, either single or multichannel
+
+    sr : int > 0
+        Sampling rate of `y`
+
+    time_map : list
+        Each element is a tuple `t` of length 2 which correspond to the input frame and desired output frame.
+        If t[1] < t[0] the track will be sped up in this area.
+        time_map[-1] must correspond to the lengths of the input audio and output audio.
+
+    rbargs
+        Additional keyword parameters for rubberband
+
+        See `rubberband -h` for details.
+
+    Returns
+    -------
+    y_stretch : np.ndarray
+        Time-stretched audio
+
+    Raises
+    ------
+    ValueError
+        if `rate <= 0`
+    '''
+
+    if rbargs is None:
+        rbargs = dict()
+        
+    time_stretch = time_map[-1][1]/time_map[-1][0]
+
+    rbargs.setdefault('--time', time_stretch)
+
+    
+    fs, stretch_file_name = tempfile.mkstemp(suffix='.txt')
+    os.close(fs)
+
+    stretch_file = open(stretch_file_name, 'w')
+    for t in time_map:
+        stretch_file.write("%d %d\n" %(t[0], t[1]))
+    stretch_file.close()    
+    
+    rbargs.setdefault('--timemap', stretch_file_name)
+    
+    y_stretch = __rubberband(y, sr, **rbargs)
+    os.unlink(stretch_file_name)
+    
+    return y_stretch
+
+
 def pitch_shift(y, sr, n_steps, rbargs=None):
     '''Apply a pitch shift to an audio time series.
 

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -46,10 +46,10 @@ def channels(request):
 
 @pytest.fixture
 def time_map(num_samples, request):
-    return [(0, 0), 
-    (num_samples//4, num_samples//4), 
-    ((3*num_samples)//4, num_samples//2), 
-    (num_samples, (3*num_samples)//4)]
+    return [(0, 0),
+            (num_samples//4, num_samples//4),
+            ((3*num_samples)//4, num_samples//2),
+            (num_samples, (3*num_samples)//4)]
 
 
 @pytest.fixture

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -130,7 +130,9 @@ def test_timemap_stretch(sr, num_samples, freq, time_map):
     fft_s = np.abs(np.fft.fft(y_s))
     fft_s = fft_s[:len(fft_s)//2]
 
-    assert np.argmax(fft) / len(fft) == np.argmax(fft_s) / len(fft_s)
+    assert np.isclose(np.argmax(fft) / len(fft),
+                      np.argmax(fft_s) / len(fft_s),
+                      rtol=1e-3)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -43,6 +43,9 @@ def n_step(request):
 def channels(request):
     return request.param
 
+@pytest.fixture
+def time_map(num_samples, request):
+    return [(0, 0), (num_samples//4, num_samples//4), ((3*num_samples)//4, num_samples//2), (num_samples, (3*num_samples)//4)]
 
 @pytest.fixture
 def random_signal(channels, num_samples):
@@ -115,7 +118,7 @@ def test_timemap_stretch(sr, num_samples, freq, time_map):
 
     assert len(y) * time_map[-1][1] == len(y_s) * time_map[-1][0]
 
-    # Make sure the the stretched audio signal has the same note as the original
+    # Make sure the stretched audio signal has the same note as the original
     fft = np.abs(np.fft.fft(y))
     fft = fft[:len(fft)//2]
 

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -115,6 +115,32 @@ def test_pitch(sr, num_samples, freq, n_step):
     assert np.allclose(s_s / s_s[0], s_f / s_f[0], atol=1e-2)
 
 
+@pytest.mark.parametrize(
+    "time_map",
+    [
+        pytest.mark.xfail([(0, 0), (16000, -8000)], raises=ValueError),
+        pytest.mark.xfail([(0, 0), (-16000, 8000)], raises=ValueError),
+        pytest.mark.xfail([(0, 0), (12000, 8000)], raises=ValueError),
+        pytest.mark.xfail([(0, 0), (8000, 6000), (4000, 4000),
+                          (16000, 12000)], raises=ValueError)
+    ]
+)
+def test_fails_timemap_stretch(time_map):
+    sr, num_samples, freq = 16000, 16000, 500
+    y = np.cos(2 * np.pi * freq * np.arange(num_samples)/sr)
+    # Apply time strech
+    y_s = pyrubberband.timemap_stretch(y, sr, time_map)
+
+    assert np.isclose(len(y_s), time_map[-1][1], rtol=1e-3)
+
+    # Make sure that the peak frequency of `y_s` is `freq`
+    n = len(y_s)
+    fft = np.abs(np.fft.fft(y_s))
+    peak_freq = np.argmax(fft[:n//2]) * sr / n
+
+    assert np.isclose(peak_freq, freq, rtol=1e-1)
+
+
 def test_timemap_stretch(sr, num_samples, freq, time_map):
 
     y = np.cos(2 * np.pi * freq * np.arange(num_samples)/sr)

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -43,9 +43,14 @@ def n_step(request):
 def channels(request):
     return request.param
 
+
 @pytest.fixture
 def time_map(num_samples, request):
-    return [(0, 0), (num_samples//4, num_samples//4), ((3*num_samples)//4, num_samples//2), (num_samples, (3*num_samples)//4)]
+    return [(0, 0), 
+    (num_samples//4, num_samples//4), 
+    ((3*num_samples)//4, num_samples//2), 
+    (num_samples, (3*num_samples)//4)]
+
 
 @pytest.fixture
 def random_signal(channels, num_samples):

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -121,18 +121,14 @@ def test_timemap_stretch(sr, num_samples, freq, time_map):
     # Apply time strech
     y_s = pyrubberband.timemap_stretch(y, sr, time_map)
 
-    assert len(y) * time_map[-1][1] == len(y_s) * time_map[-1][0]
+    assert np.isclose(len(y_s), time_map[-1][1], rtol=1e-3)
 
-    # Make sure the stretched audio signal has the same note as the original
-    fft = np.abs(np.fft.fft(y))
-    fft = fft[:len(fft)//2]
+    # Make sure that the peak frequency of `y_s` is `freq`
+    n = len(y_s)
+    fft = np.abs(np.fft.fft(y_s))
+    peak_freq = np.argmax(fft[:n//2]) * sr / n
 
-    fft_s = np.abs(np.fft.fft(y_s))
-    fft_s = fft_s[:len(fft_s)//2]
-
-    assert np.isclose(np.argmax(fft) / len(fft),
-                      np.argmax(fft_s) / len(fft_s),
-                      rtol=1e-1)
+    assert np.isclose(peak_freq, freq, rtol=1e-1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -132,7 +132,7 @@ def test_timemap_stretch(sr, num_samples, freq, time_map):
 
     assert np.isclose(np.argmax(fft) / len(fft),
                       np.argmax(fft_s) / len(fft_s),
-                      rtol=1e-3)
+                      rtol=1e-1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pyrb.py
+++ b/tests/test_pyrb.py
@@ -107,6 +107,24 @@ def test_pitch(sr, num_samples, freq, n_step):
     assert np.allclose(s_s / s_s[0], s_f / s_f[0], atol=1e-2)
 
 
+def test_timemap_stretch(sr, num_samples, freq, time_map):
+
+    y = np.cos(2 * np.pi * freq * np.arange(num_samples)/sr)
+    # Apply time strech
+    y_s = pyrubberband.timemap_stretch(y, sr, time_map)
+
+    assert len(y) * time_map[-1][1] == len(y_s) * time_map[-1][0]
+
+    # Make sure the the stretched audio signal has the same note as the original
+    fft = np.abs(np.fft.fft(y))
+    fft = fft[:len(fft)//2]
+
+    fft_s = np.abs(np.fft.fft(y_s))
+    fft_s = fft_s[:len(fft_s)//2]
+
+    assert np.argmax(fft) / len(fft) == np.argmax(fft_s) / len(fft_s)
+
+
 @pytest.mark.parametrize(
     "cli",
     [pytest.mark.xfail('rubberband-missing', raises=RuntimeError),


### PR DESCRIPTION
I added a function that allows users to perform the timemap stretch option of rubberband  (see doc [here](https://breakfastquay.com/rubberband/usage.txt)). It is largely based on the current code.

I've also added a test in the tests file.

Here is an example of time map that stretches a 5 seconds audio file by:
Leaving second 0 to 1 as is
Speeding up seconds 1 to 3 by a factor 2. (it corresponds to seconds 1 to 2 in the stretched audio)
Leaving the rest of the audio as is.

`time_map = [(0, 0), (sr, sr), (3*sr, 2*sr), (5*sr, 4*sr)]`