### PR TITLE
require soundfile, not pysoundfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,8 @@ tools:
 
 -  Code with good test coverage (at least 99%), check with:
 
-          $ pip install pytest pytest-cov pytest-faulthandler
-          $ python setup.py build_ext -i
-          $ py.test --cov-report term-missing --cov pyrubberband
+          $ pip install -e .[tests]
+          $ pytest
 
 Documentation
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [tool:pytest]
-addopts = --ignore docs/conf.py --cov-report term-missing --cov pyrubberband --pep8
+addopts = --ignore docs/conf.py --cov-report term-missing --cov pyrubberband

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,12 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     keywords='audio music sound',
     license='ISC',
     install_requires=[
+        'numpy',
         'six',
         'soundfile>=0.8.0',
     ],
@@ -36,14 +38,12 @@ setup(
         'tests': [
             'pytest',
             'pytest-cov',
-            'pytest-pep8',
             'contextlib2',
         ]
     },
     test_require=[
         'pytest',
         'pytest-cov',
-        'pytest-pep8',
         'contextlib2',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license='ISC',
     install_requires=[
         'six',
-        'pysoundfile>=0.8.0',
+        'soundfile>=0.8.0',
     ],
     extras_require={
         'docs': ['numpydoc'],


### PR DESCRIPTION
pysoundfile is deprecated: https://github.com/bastibe/PySoundFile

#### What does this implement/fix? Explain your changes.

The PySoundFile page on GitHub indicates that PySoundFile was renamed to SoundFile.

The install command is now `pip install soundfile`.

#### Any other comments?

I had to comment out the pytest lines in `setup.cfg` in order to run the tests.  But, the tests did pass!

Running pytest with `setup.cfg` as is results in:

```
↪ pytest
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.6.12, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /Users/nw_henderson/github.com/nwh/pyrubberband, configfile: setup.cfg
plugins: cov-2.10.1, pep8-1.0.6
collected 0 items / 1 error                                                                                                                                                         
Coverage.py warning: No data was collected. (no-data-collected)

====================================================================================== ERRORS =======================================================================================
___________________________________________________________________________ ERROR collecting test session ___________________________________________________________________________
Direct construction of Pep8Item has been deprecated, please use Pep8Item.from_parent.
See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.

---------- coverage: platform darwin, python 3.6.12-final-0 ----------
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
pyrubberband/__init__.py       3      3     0%   4-7
pyrubberband/pyrb.py          72     72     0%   3-257
pyrubberband/version.py        1      1     0%   4
--------------------------------------------------------
TOTAL                         76     76     0%

============================================================================== short test summary info ==============================================================================
ERROR 
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================= 1 error in 0.09s ==================================================================================
```
 
