### PR TITLE
Preserve original data type

### DIFF
--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -74,7 +74,7 @@ def __rubberband(y, sr, **kwargs):
         subprocess.check_call(arguments, stdout=DEVNULL, stderr=DEVNULL)
 
         # Load the processed audio.
-        y_out, _ = sf.read(outfile, always_2d=True)
+        y_out, _ = sf.read(outfile, always_2d=True, dtype=y.dtype)
 
         # make sure that output dimensions matches input
         if y.ndim == 1:


### PR DESCRIPTION
[`sf.read` defaults to reading files as float64](https://pysoundfile.readthedocs.io/en/latest/#soundfile.read), which causes pyrubberband to implicitly convert all processed audio into float64 regardless of the original data type. This change makes pyrubberband preserve the data type of the input by reading it back in the same format.