### PR TITLE
Adding support for single valued `rbargs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ Example usage
 >>> y, sr = sf.read("test.wav")
 >>> # Play back at double speed
 >>> y_stretch = pyrb.time_stretch(y, sr, 2.0)
+>>> # Pass rbargs supported in Rubberband CLI. See(rubberband -h or https://breakfastquay.com/rubberband/usage.txt)
+>>> y_stretch = pyrb.time_stretch(y, sr, 2.0, rbargs={'-c':'5', '--no_transients':''})
 ```

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -113,9 +113,11 @@ def time_stretch(y, sr, rate, rbargs=None):
     rate : float > 0
         Desired playback rate.
 
-    rbargs
+    rbargs : {key:value, key:value}
         Additional keyword parameters for rubberband
-
+        Accepts a dictionary of key:value pairs supported by `rubberband`.
+        type(key and value) == str()
+        For single valued `rbargs`, pass empty string for `value`.
         See `rubberband -h` for details.
 
     Returns
@@ -168,9 +170,11 @@ def timemap_stretch(y, sr, time_map, rbargs=None):
         `time_map[-1]` must correspond to the lengths of the source audio and
         target audio.
 
-    rbargs
+    rbargs : {key:value, key:value}
         Additional keyword parameters for rubberband
-
+        Accepts a dictionary of key:value pairs supported by `rubberband`.
+        type(key and value) == str()
+        For single valued `rbargs`, pass empty string for `value`.
         See `rubberband -h` for details.
 
     Returns
@@ -236,9 +240,11 @@ def pitch_shift(y, sr, n_steps, rbargs=None):
     n_steps : float
         Shift by `n_steps` semitones.
 
-    rbargs
+    rbargs : {key:value, key:value}
         Additional keyword parameters for rubberband
-
+        Accepts a dictionary of key:value pairs supported by `rubberband`.
+        type(key and value) == str()
+        For single valued `rbargs`, pass empty string for `value`.
         See `rubberband -h` for details.
 
     Returns

--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -67,7 +67,8 @@ def __rubberband(y, sr, **kwargs):
 
         for key, value in six.iteritems(kwargs):
             arguments.append(str(key))
-            arguments.append(str(value))
+            if len(str(value).strip()):
+                arguments.append(str(value))
 
         arguments.extend([infile, outfile])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/bmcfee/pyrubberband/blob/master/CONTRIBUTING.md#how-to-contribute
-->
#### Reference Issue
<!-- Example: Fixes #123 -->
Fixes Issue #21 

#### What does this implement/fix? Explain your changes.
Arguments to CLI, parsed through `rbargs` can be single or dual valued, but currently breaks if it's single valued. for e.g. `pyrb.pitch_shift(wav_data, n_semitones, rbargs={'--formant'})` won't work.

This current implementation allows us to restore that functionality by parsing an empty  value `''`  to the CLI.

This fix allows us to parse flags through in the form of `rbargs={'--flag' : ''}` while retaining the `kwargs` format.

#### Any other comments?
I do feel that this leaves us a bit wanting for something nicer but it's just a step forward to allow some functionality for now. We can explore making the extra argument as `None` instead of `''`, but I figured this is probably just as intuitive for these occasional use-cases.