### PR TITLE
add feature for parsing ableton ASD file

### DIFF
--- a/pyrubberband/pyrb.py
+++ b/pyrubberband/pyrb.py
@@ -8,6 +8,7 @@
     pitch_shift
     time_stretch
     timemap_stretch
+    ableton_asd_to_time_map
 '''
 
 
@@ -19,7 +20,7 @@ import numpy as np
 import soundfile as sf
 
 
-__all__ = ['time_stretch', 'pitch_shift', 'timemap_stretch']
+__all__ = ['time_stretch', 'pitch_shift', 'timemap_stretch', 'ableton_asd_to_time_map']
 
 __RUBBERBAND_UTIL = 'rubberband'
 
@@ -255,3 +256,112 @@ def pitch_shift(y, sr, n_steps, rbargs=None):
     rbargs.setdefault('--pitch', n_steps)
 
     return __rubberband(y, sr, **rbargs)
+
+def ableton_asd_to_time_map(filepath, y, sr, bpm):
+
+    '''Parse an Ableton `asd` file into a time map to be used with `timemap_stretch`.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to an Ableton warp file with ".asd" extension 
+
+    y : np.ndarray [shape=(n,) or (n, c)]
+        Audio time series, either single or multichannel
+
+    sr : int > 0
+        Sampling rate of `y`
+
+    bpm : float > 0
+        The beats-per-minute of the time map which will be returned
+
+    Returns
+    -------
+    time_map : list
+        Each element is a tuple `t` of length 2 which corresponds to the
+        source sample position and target sample position.
+
+        If `t[1] < t[0]` the track will be sped up in this area.
+
+        Refer to the function `timemap_stretch`.
+    '''
+
+    if not os.path.isfile(filepath):
+        raise FileNotFoundError(f"No such file or directory: '{filepath}'")
+
+    f = open(filepath, 'rb')
+    asd_bin = f.read()
+    f.close()
+
+    index = asd_bin.find(b'SampleOverViewLevel')
+    index = asd_bin.find(b'SampleOverViewLevel', index+1)
+    index += 90
+
+    # a double is 8 bytes
+    size_double = 8
+
+    import struct
+    def read_double(buffer, index):
+        return struct.unpack('d', buffer[index:index+size_double])[0]
+
+    def read_bool(buffer, index):
+        return struct.unpack('?', buffer[index:index+1])[0]
+
+    loop_start = read_double(asd_bin, index)
+    index += size_double
+    loop_end = read_double(asd_bin, index)
+    index += size_double
+    sample_offset = read_double(asd_bin, index)
+    index += size_double
+    hidden_loop_start = read_double(asd_bin, index)
+    index += size_double
+    hidden_loop_end = read_double(asd_bin, index)
+    index += size_double
+    end_marker = read_double(asd_bin, index)
+    index += size_double
+
+    start_marker = loop_start + sample_offset
+
+    # These values are measured in quarter notes relative to the 1.1.1 marker.
+    # loop_start, loop_end, hidden_loop_start, hidden_loop_end, start_marker, end_marker
+
+    warp_markers = []
+    index = asd_bin.find(b'WarpMarker')
+    last_good_index = -1
+    while True:
+
+        index = asd_bin.find(b'WarpMarker', index+1)
+        if index < 0:
+            index = last_good_index
+            break
+
+        index += 14  # WarpMarker is 10 bytes. Then add 4.
+
+        marker_seconds = read_double(asd_bin, index)
+        index += size_double
+        marker_beats = read_double(asd_bin, index)
+
+        warp_markers.append((marker_beats, marker_seconds))
+
+        last_good_index = index
+
+    index += 15
+    # The loop_on value can be found some bytes after the last warp marker.
+    loop_on = read_bool(asd_bin, index)
+
+    time_map = []
+    for marker_beats, marker_seconds in warp_markers:
+        
+        time_map.append([int(marker_seconds*sr), int(marker_beats*(60./bpm)*sr)])
+
+    # The difference in beats divided by the difference in seconds, times 60 seconds = BPM.
+    last_bpm = (warp_markers[-1][0] - warp_markers[-2][0]) / (warp_markers[-1][1] - warp_markers[-2][1]) * 60.
+
+    num_samples = y.shape[1] if len(y.shape) > 1 else y.shape[0]
+
+    # Extrapolate the last bpm 
+    mapped_last_sample = time_map[-1][1] + (num_samples-time_map[-1][0])*last_bpm/bpm
+
+    time_map.append([num_samples, mapped_last_sample])
+
+    return time_map


### PR DESCRIPTION
#### Reference Issue
N/A
#### What does this implement/fix? Explain your changes.
This adds a function `ableton_asd_to_time_map` for parsing Ableton `.asd` warp files into a `time_map` list to be used with `pyrb.timemap_stretch`.


#### Any other comments?

Example usage:
```python
import pyrb
import librosa

sr = 44100
bpm = 120.

y = librosa.load('song.wav', sr=sr)[0]
time_map = pyrb.ableton_asd_to_time_map('song.wav.asd', y, sr, bpm)
new_song = pyrb.timemap_stretch(y, sr, time_map)

from scipy import io
import scipy.io.wavfile
io.wavfile.write('new_song.wav', sr, new_song )
```

I wrote the code after reading [https://github.com/jtxx000/extract-warp-markers](https://github.com/jtxx000/extract-warp-markers). That project showed how to extract the BPM. I did some extra probing to find out how to get other fields such as `loop_start`, `loop_end`, `start_marker`, `end_marker`, `loop_on`. I think having that information could be really useful for other developers. Perhaps pyrubberband could handle looping one day.

It's possible that this function could break if Ableton changes their ASD format... But I still think it's worth sharing. I'm using Ableton 10.1.30.