### PR TITLE
Migrate some dependency

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -1,6 +1,12 @@
 name: CI-minimal
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Install rubberband-cli and ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y rubberband-cli ffmpeg
+
       - name: Install dependencies
         run: pip install -e .[tests]
 

--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -1,0 +1,25 @@
+name: CI-minimal
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: pip install -e .[tests]
+
+      - name: Run test
+        run: python -m pytest tests
+

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -34,7 +34,7 @@ if [ ! -d "$src" ]; then
 
         conda install -c conda-forge ffmpeg
 
-        pip install pysoundfile
+        pip install soundfile
         pip install python-coveralls
         pip install pytest-cov
         source deactivate

--- a/pyrubberband/__init__.py
+++ b/pyrubberband/__init__.py
@@ -3,5 +3,5 @@
 # CREATED:2015-03-02 11:50:46 by Brian McFee <brian.mcfee@nyu.edu>
 '''A python wrapper for rubberband'''
 
-from .pyrb import *
 from .version import version as __version__
+from .pyrb import *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,48 @@
 [tool:pytest]
 addopts = --ignore docs/conf.py --cov-report term-missing --cov pyrubberband
+
+
+[metadata]
+name = pyrubberband
+author = Brian McFee
+author_email = brian.mcfee@nyu.edu
+version = attr: pyrubberband.version.version
+url = http://github.com/bmcfee/pyrubberband
+download_url = http://github.com/bmcfee/pyrubberband/releases
+description = Python module to wrap rubberband
+long_description = A python module to wrap rubberband.
+keywords = audio, music, sound
+license = ISC
+license_files = LICENSE
+classifiers =
+    License :: OSI Approved :: ISC License (ISCL)
+    Programming Language :: Python
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Topic :: Multimedia :: Sound/Audio :: Analysis
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+
+
+[options]
+packages = find:
+install_package_data = True
+python_requires >= 3.6
+install_requires =
+    numpy
+    six
+    soundfile >= 0.12.1
+
+[options.extras_require]
+docs =
+    numpydoc
+tests =
+    pytest
+    pytest-cov
+    contextlib2

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 packages = find:
 install_package_data = True
-python_requires >= 3.6
+python_requires = >= 3.6
 install_requires =
     numpy
     six

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 packages = find:
 install_package_data = True
-python_requires = >= 3.6
+python_requires = >=3.6
 install_requires =
     numpy
     six

--- a/setup.py
+++ b/setup.py
@@ -1,46 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-import importlib.util
+if __name__ == '__main__':
+    setup()
 
-spec = importlib.util.spec_from_file_location('pyrubberband.version', 'pyrubberband/version.py')
-version = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(version)
-
-setup(
-    name='pyrubberband',
-    version=version.version,
-    description='Python module to wrap rubberband',
-    author='Brian McFee',
-    author_email='brian.mcfee@nyu.edu',
-    url='http://github.com/bmcfee/pyrubberband',
-    download_url='http://github.com/bmcfee/pyrubberband/releases',
-    packages=find_packages(),
-    long_description="""A python module to wrap rubberband.""",
-    classifiers=[
-        "License :: OSI Approved :: ISC License (ISCL)",
-        "Programming Language :: Python",
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "Topic :: Multimedia :: Sound/Audio :: Analysis",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-    ],
-    keywords='audio music sound',
-    license='ISC',
-    install_requires=[
-        'numpy',
-        'six',
-        'soundfile>=0.12.1',
-    ],
-    extras_require={
-        'docs': ['numpydoc'],
-        'tests': [
-            'pytest',
-            'pytest-cov',
-            'contextlib2',
-        ]
-    },
-)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'numpy',
         'six',
-        'soundfile>=0.8.0',
+        'soundfile>=0.12.1',
     ],
     extras_require={
         'docs': ['numpydoc'],

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup, find_packages
 
-import imp
+import importlib.util
 
-version = imp.load_source('pyrubberband.version', 'pyrubberband/version.py')
+spec = importlib.util.spec_from_file_location('pyrubberband.version', 'pyrubberband/version.py')
+version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(version)
 
 setup(
     name='pyrubberband',
@@ -41,9 +43,4 @@ setup(
             'contextlib2',
         ]
     },
-    test_require=[
-        'pytest',
-        'pytest-cov',
-        'contextlib2',
-    ]
 )


### PR DESCRIPTION
#### Reference Issue
Fix #28

#### What does this implement/fix? Explain your changes.
1. Migrate to `importlib` from `imp`. 
Done by : https://github.com/python/cpython/issues/104212
2. `pysoundfile`  is now deprecated and use `soundfile`. ( It was problematic if other packages used `soundfile`.)

Tested on python `3.10`, `3.11`, `3.12` and all worked fine.

 
